### PR TITLE
implement unit tests, refactoring datamanager to support mocking

### DIFF
--- a/CoordImporter.Tests/CoordImporter.Tests.csproj
+++ b/CoordImporter.Tests/CoordImporter.Tests.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
+        <DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
+        <DalamudLibPath Condition="$(DALAMUD_HOME) != ''">$(DALAMUD_HOME)/</DalamudLibPath>
+    </PropertyGroup>
+    
+    <PropertyGroup>
+        <TargetFramework>net7.0-windows</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblySearchPaths>$(AssemblySearchPaths);$(DalamudLibPath)</AssemblySearchPaths>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <Reference Include="FFXIVClientStructs" Private="false" />
+        <Reference Include="Newtonsoft.Json" Private="false" />
+        <Reference Include="Dalamud" Private="false" />
+        <Reference Include="ImGui.NET" Private="false" />
+        <Reference Include="ImGuiScene" Private="false" />
+        <Reference Include="Lumina" Private="false" />
+        <Reference Include="Lumina.Excel" Private="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Reference Include="Dalamud" />
+        <Reference Include="Lumina" />
+        <Reference Include="Lumina.Excel" />
+        <PackageReference Include="Lib.Harmony" Version="2.3.0-prerelease.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CoordImporter\CoordImporter.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/CoordImporter.Tests/GlobalUsings.cs
+++ b/CoordImporter.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/CoordImporter.Tests/ParserTests.cs
+++ b/CoordImporter.Tests/ParserTests.cs
@@ -125,8 +125,3 @@ namespace CoordImporter.Tests
             };
     }
 }
-
-internal static class ParserTestExtensions
-{
-    
-}

--- a/CoordImporter.Tests/ParserTests.cs
+++ b/CoordImporter.Tests/ParserTests.cs
@@ -1,6 +1,7 @@
 using CoordImporter.Managers;
 using CoordImporter.Parser;
 using CSharpFunctionalExtensions;
+using Dalamud.Game.Text;
 using Dalamud.Plugin.Services;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
@@ -12,13 +13,16 @@ namespace CoordImporter.Tests
     [TestFixture]
     public class ParserTests
     {
+        private static readonly string LinkChar = SeIconChar.LinkMarker.ToIconString();
+        private static readonly string I2Char = SeIconChar.Instance2.ToIconString();
+        
         // trailing space is actually in the Siren output >:T
-        private const string TestSirenInputLine = "(Maybe: Stolas) \ue0bbThe Dravanian Hinterlands ( 26.85  , 20.05 ) ";
-        private const string TestFaloopInputLine = "Raiden [S]: Gamma - Yanxia ( 23.6, 11.4 )";
-        private const string TestBearInputLine = "The Rak'tika Greatwood ( 14.6 , 22.3 ) Supay";
-        private const string TestSirenInstancedInputLine = "(Yilan) \ue0bbThavnair\ue0b2 ( 26.8  , 20.9 )  (Instance TWO) ";
-        private const string TestFaloopInstancedInputLine = "Odin [S]: Vogaal Ja - Middle La Noscea (1) ( 8.2, 32.65 )";
-        private const string TestBearInstancedInputLine = "Thavnair 3 ( 27.6 , 25.6 ) Sugriva";
+        private static readonly string TestSirenInputLine = $@"(Maybe: Stolas) {LinkChar}The Dravanian Hinterlands ( 26.85  , 20.05 ) ";
+        private static readonly string TestFaloopInputLine = @"Raiden [S]: Gamma - Yanxia ( 23.6, 11.4 )";
+        private static readonly string TestBearInputLine = @"The Rak'tika Greatwood ( 14.6 , 22.3 ) Supay";
+        private static readonly string TestSirenInstancedInputLine = $@"(Yilan) {LinkChar}Thavnair{I2Char} ( 26.8  , 20.9 )  (Instance TWO) ";
+        private static readonly string TestFaloopInstancedInputLine = @"Odin [S]: Vogaal Ja - Middle La Noscea (1) ( 8.2, 32.65 )";
+        private static readonly string TestBearInstancedInputLine = @"Thavnair 3 ( 27.6 , 25.6 ) Sugriva";
         private static readonly MarkData TestSirenMarkData =
             new MarkData("Stolas", "The Dravanian Hinterlands", 362, 712, null, new Vector2(26.85f, 20.05f));
         private static readonly MarkData TestFaloopMarkData =

--- a/CoordImporter.Tests/ParserTests.cs
+++ b/CoordImporter.Tests/ParserTests.cs
@@ -1,0 +1,132 @@
+using CoordImporter.Managers;
+using CoordImporter.Parser;
+using CSharpFunctionalExtensions;
+using Dalamud.Plugin.Services;
+using NSubstitute;
+using NSubstitute.ReceivedExtensions;
+using System.Collections.Immutable;
+using System.Numerics;
+
+namespace CoordImporter.Tests
+{
+    [TestFixture]
+    public class ParserTests
+    {
+        // trailing space is actually in the Siren output >:T
+        private const string TestSirenInputLine = @"(Maybe: Stolas) The Dravanian Hinterlands ( 26.85  , 20.05 ) ";
+        private const string TestFaloopInputLine = @"Raiden [S]: Gamma - Yanxia ( 23.6, 11.4 )";
+        private const string TestBearInputLine = @"The Rak'tika Greatwood ( 14.6 , 22.3 ) Supay";
+        private const string TestSirenInstancedInputLine = @"(Maybe: Yilan) Thavnair ( 26.8  , 20.9 )  (Instance TWO) ";
+        private const string TestFaloopInstancedInputLine = @"Odin [S]: Vogaal Ja - Middle La Noscea (1) ( 8.2, 32.65 )";
+        private const string TestBearInstancedInputLine = @"Thavnair 3 ( 27.6 , 25.6 ) Sugriva";
+        private static readonly MarkData TestSirenMarkData =
+            new MarkData("Stolas", "The Dravanian Hinterlands", 362, 712, null, new Vector2(26.85f, 20.05f));
+        private static readonly MarkData TestFaloopMarkData =
+            new MarkData("Gamma", "Yanxia", 14, 1343, null, new Vector2(23.6f, 11.4f));
+        private static readonly MarkData TestBearMarkData =
+            new MarkData("Supay", "The Rak'tika Greatwood", 3067, 32, null, new Vector2(14.6f, 22.3f));
+        private static readonly MarkData TestSirenInstancedMarkData =
+            new MarkData("Yilan", "Thavnair", 5362, 15, 2, new Vector2(26.8f, 20.9f));
+        private static readonly MarkData TestFaloopInstancedMarkData =
+            new MarkData("Vogaal Ja", "Middle La Noscea", 83, 433, 1, new Vector2(8.2f, 32.65f));
+        private static readonly MarkData TestBearInstancedMarkData =
+            new MarkData("Sugriva", "Thavnair", 316, 2283, 3, new Vector2(27.6f, 25.6f));
+        private static readonly IReadOnlyList<string> TestInputLines = new[]
+        {
+            TestSirenInputLine,
+            TestFaloopInputLine,
+            TestBearInputLine,
+            TestSirenInstancedInputLine,
+            TestFaloopInstancedInputLine,
+            TestBearInstancedInputLine
+        }.ToImmutableList();
+
+        [SetUp]
+        public void Setup()
+        {
+            Plugin.Chat = Substitute.For<IChatGui>();
+            Plugin.Logger = Substitute.For<IPluginLog>();
+            Plugin.DataManagerManager = Substitute.For<IDataManagerManager>();
+        }
+
+        [Test] public void SirenCanParse() =>
+            TestCanParse(ParserType.Siren, 0, 3);
+
+        [Test] public void FaloopCanParse() =>
+            TestCanParse(ParserType.Faloop, 1, 4);
+
+        [Test] public void BearCanParse() =>
+            TestCanParse(ParserType.Bear, 2, 5);
+
+        private void TestCanParse(ParserType parserType, params int[] trueIndecies)
+        {
+            // DATA
+            var parser = GetParser(parserType);
+            var expected = TestInputLines.Select(_ => false).ToList();
+            trueIndecies.ForEach(index => expected[index] = true);
+            
+            // WHEN
+            var actual = TestInputLines.Select(parser.CanParseLine).ToList();
+            
+            // THEN
+            Assert.That(actual, Is.EquivalentTo(expected));
+        }
+
+        [Test] public void SirenParsesSuccessfully() =>
+            TestParsesSuccessfully(ParserType.Siren, TestSirenInputLine, TestSirenMarkData);
+
+        [Test] public void FaloopParsesSuccessfully() =>
+            TestParsesSuccessfully(ParserType.Faloop, TestFaloopInputLine, TestFaloopMarkData);
+
+        [Test] public void BearParsesSuccessfully() =>
+            TestParsesSuccessfully(ParserType.Bear, TestBearInputLine, TestBearMarkData);
+
+        [Test] public void SirenParsesInstanceSuccessfully() =>
+            TestParsesSuccessfully(ParserType.Siren, TestSirenInstancedInputLine, TestSirenInstancedMarkData);
+
+        [Test] public void FaloopParsesInstanceSuccessfully() =>
+            TestParsesSuccessfully(ParserType.Faloop, TestFaloopInstancedInputLine, TestFaloopInstancedMarkData);
+
+        [Test] public void BearParsesInstanceSuccessfully() =>
+            TestParsesSuccessfully(ParserType.Bear, TestBearInstancedInputLine, TestBearInstancedMarkData);
+
+        private void TestParsesSuccessfully(ParserType parserType, string inputLine, MarkData expected)
+        {
+            // DATA
+            var parser = GetParser(parserType);
+            
+            // GIVEN
+            Plugin.DataManagerManager.GetMapDataByName(Arg.Any<string>())
+                .Returns(new MapData(expected.TerritoryId, expected.MapId));
+            
+            // WHEN
+            var actual = parser.Parse(inputLine);
+            
+            // THEN
+            Plugin.DataManagerManager.Received(Quantity.Exactly(1)).GetMapDataByName(expected.MapName);
+            
+            Assert.That(actual, Is.EqualTo(Result.Success<MarkData, string>(expected)));
+        }
+
+        public enum ParserType
+        {
+            Siren,
+            Faloop,
+            Bear,
+        }
+
+        private static ITrackerParser GetParser(ParserType parserType) =>
+            parserType switch
+            {
+                ParserType.Siren => new SirenParser(),
+                ParserType.Faloop => new FaloopParser(),
+                ParserType.Bear => new BearParser(),
+                _ => throw new Exception($"Unknown parser: {parserType}")
+            };
+    }
+}
+
+internal static class ParserTestExtensions
+{
+    
+}

--- a/CoordImporter.Tests/ParserTests.cs
+++ b/CoordImporter.Tests/ParserTests.cs
@@ -13,12 +13,12 @@ namespace CoordImporter.Tests
     public class ParserTests
     {
         // trailing space is actually in the Siren output >:T
-        private const string TestSirenInputLine = @"(Maybe: Stolas) The Dravanian Hinterlands ( 26.85  , 20.05 ) ";
-        private const string TestFaloopInputLine = @"Raiden [S]: Gamma - Yanxia ( 23.6, 11.4 )";
-        private const string TestBearInputLine = @"The Rak'tika Greatwood ( 14.6 , 22.3 ) Supay";
-        private const string TestSirenInstancedInputLine = @"(Maybe: Yilan) Thavnair ( 26.8  , 20.9 )  (Instance TWO) ";
-        private const string TestFaloopInstancedInputLine = @"Odin [S]: Vogaal Ja - Middle La Noscea (1) ( 8.2, 32.65 )";
-        private const string TestBearInstancedInputLine = @"Thavnair 3 ( 27.6 , 25.6 ) Sugriva";
+        private const string TestSirenInputLine = "(Maybe: Stolas) \ue0bbThe Dravanian Hinterlands ( 26.85  , 20.05 ) ";
+        private const string TestFaloopInputLine = "Raiden [S]: Gamma - Yanxia ( 23.6, 11.4 )";
+        private const string TestBearInputLine = "The Rak'tika Greatwood ( 14.6 , 22.3 ) Supay";
+        private const string TestSirenInstancedInputLine = "(Yilan) \ue0bbThavnair\ue0b2 ( 26.8  , 20.9 )  (Instance TWO) ";
+        private const string TestFaloopInstancedInputLine = "Odin [S]: Vogaal Ja - Middle La Noscea (1) ( 8.2, 32.65 )";
+        private const string TestBearInstancedInputLine = "Thavnair 3 ( 27.6 , 25.6 ) Sugriva";
         private static readonly MarkData TestSirenMarkData =
             new MarkData("Stolas", "The Dravanian Hinterlands", 362, 712, null, new Vector2(26.85f, 20.05f));
         private static readonly MarkData TestFaloopMarkData =

--- a/CoordImporter.Tests/packages.lock.json
+++ b/CoordImporter.Tests/packages.lock.json
@@ -1,0 +1,188 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net7.0-windows7.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[3.2.0, )",
+        "resolved": "3.2.0",
+        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+      },
+      "Lib.Harmony": {
+        "type": "Direct",
+        "requested": "[2.3.0-prerelease.2, )",
+        "resolved": "2.3.0-prerelease.2",
+        "contentHash": "96ijLrds6W9otxxKIopzQS68tAm6sFbfWBSxfnxkWb9QmE84NJJH/6mutr8sqQ+Dv5Oqg6fAZBdcM6WfB6khVA==",
+        "dependencies": {
+          "MonoMod.Core": "1.0.0-prerelease.2",
+          "System.Text.Json": "5.0.2"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.7.1, )",
+        "resolved": "17.7.1",
+        "contentHash": "o1qyqDOR8eMuQrC1e5EMMcE+Wm3rwES5aHNWaJpi2A5qwVOru23zsdXkndT6hgl79QsJsqKp+/RNcayIzpHjvA==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.7.1",
+          "Microsoft.TestPlatform.TestHost": "17.7.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.1.0, )",
+        "resolved": "5.1.0",
+        "contentHash": "ZCqOP3Kpp2ea7QcLyjMU4wzE+0wmrMN35PQMsdPOHYc2IrvjmusG9hICOiqiOTPKN0gJon6wyCn6ZuGHdNs9hQ==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "NUnit": {
+        "type": "Direct",
+        "requested": "[3.13.3, )",
+        "resolved": "3.13.3",
+        "contentHash": "KNPDpls6EfHwC3+nnA67fh5wpxeLb3VLFAfLxrug6JMYDLHH6InaQIWR7Sc3y75d/9IKzMksH/gi08W7XWbmnQ==",
+        "dependencies": {
+          "NETStandard.Library": "2.0.0"
+        }
+      },
+      "NUnit.Analyzers": {
+        "type": "Direct",
+        "requested": "[3.6.1, )",
+        "resolved": "3.6.1",
+        "contentHash": "RKP9tpKfl3DmRgUDGgh3XM3XzeLMrCXXMZm6vm1nMsObZ6vtQL1L9NrK7+oZh1jWearvNsbMis2+AIOY3NFmow=="
+      },
+      "NUnit3TestAdapter": {
+        "type": "Direct",
+        "requested": "[4.4.2, )",
+        "resolved": "4.4.2",
+        "contentHash": "vA/iHYcR+LYw+pRWQugckC/zW2fXHaqMr2uA82NOBt8v4YK4wMJrQ7QC8XLc7PjetEZ96cPbBTWsDDtmQiRZTA=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "CSharpFunctionalExtensions": {
+        "type": "Transitive",
+        "resolved": "2.40.3",
+        "contentHash": "G+t+bf39aixVFN3O3Q5LoE0zy3o8QlV3mv3ATw76XwDRWkE9eFRLzZdx9HH9fgbPpasfP4kr8cnnXIP+Z7GcrQ=="
+      },
+      "DalamudPackager": {
+        "type": "Transitive",
+        "resolved": "2.1.12",
+        "contentHash": "Sc0PVxvgg4NQjcI8n10/VfUQBAS4O+Fw2pZrAqBdRMbthYGeogzu5+xmIGCGmsEZ/ukMOBuAqiNiB5qA3MRalg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.7.1",
+        "contentHash": "NmGwM2ZJy4CAMdJYIp53opUjnXsMbzASX5oQzgxORicJsgz5Lp50fnRI8OmQ/kYNg6dHfr3IjuUoXbsotDX+KA=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.7.1",
+        "contentHash": "nDmV03yHIdAiG5J3ZEjMyJM2XDjmWORuKgbrGzqlAipBEjUuy5Z5S7WwSqUv9OiaUrtCn9dNYmjfMELUi08leQ==",
+        "dependencies": {
+          "NuGet.Frameworks": "6.5.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.7.1",
+        "contentHash": "WCU1NyBarz0tih+I9K5OWN1dVo3z562Iek/VAqWNWRFWw1GeUGqB61iixrBvZO77sjTtBc1cXO8H95uImfmEdw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.7.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Mono.Cecil": {
+        "type": "Transitive",
+        "resolved": "0.11.4",
+        "contentHash": "IC1h5g0NeJGHIUgzM1P82ld57knhP0IcQfrYITDPXlNpMYGUrsG5TxuaWTjaeqDNQMBDNZkB8L0rBnwsY6JHuQ=="
+      },
+      "MonoMod.Backports": {
+        "type": "Transitive",
+        "resolved": "1.0.0-prerelease.2",
+        "contentHash": "x7ap9fLFhLllTNorvWt8IuVP4NwH3+qfpO/AmoTM/Fcq11DgTyo0up+udsMFdw2nCpxh1//xmVydpac96ulqlg==",
+        "dependencies": {
+          "MonoMod.ILHelpers": "1.0.0-prerelease.2"
+        }
+      },
+      "MonoMod.Core": {
+        "type": "Transitive",
+        "resolved": "1.0.0-prerelease.2",
+        "contentHash": "nQYYvooFTMfH7KljHXg1eHCm5CpCmYgJTTdEMVgkhKOdfco/Gw9h/KYC1EXOMNjQdmi/hwcFP5PgF7W6XWVMRg==",
+        "dependencies": {
+          "Mono.Cecil": "0.11.4",
+          "MonoMod.Backports": "1.0.0-prerelease.2",
+          "MonoMod.ILHelpers": "1.0.0-prerelease.2",
+          "MonoMod.Utils": "25.0.0-prerelease.2"
+        }
+      },
+      "MonoMod.ILHelpers": {
+        "type": "Transitive",
+        "resolved": "1.0.0-prerelease.2",
+        "contentHash": "jB1JpcLGtKsWFIPItn/eQgmKwzPBKoDJnnBRDxWV3Ma4am6wPx8ynXXTwoTZOFi5gfHvkqK0RIu9MwJbwRCmow=="
+      },
+      "MonoMod.Utils": {
+        "type": "Transitive",
+        "resolved": "25.0.0-prerelease.2",
+        "contentHash": "8NWKe2Kc/CIt8BpK+DcZnc+23XP5+LG+nuUP8ELQ32qxad1JOBjLMRmCXLfxpk74z37XuBpTJUABa9pwPY2MXg==",
+        "dependencies": {
+          "Mono.Cecil": "0.11.4",
+          "MonoMod.Backports": "1.0.0-prerelease.2",
+          "MonoMod.ILHelpers": "1.0.0-prerelease.2"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "7jnbRU+L08FXKMxqUflxEXtVymWvNOrS8yHgu9s6EM8Anr6T/wIX4nZ08j/u3Asz+tCufp3YVwFSEvFTPYmBPA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "6.5.0",
+        "contentHash": "QWINE2x3MbTODsWT1Gh71GaGb5icBz4chS8VYvTgsBnsi8esgN6wtHhydd7fvToWECYGq7T4cgBBDiKD/363fg=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.2",
+        "contentHash": "I47dVIGiV6SfAyppphxqupertT/5oZkYLDCX6vC3HpOI4ZLjyoKAreUoem2ie6G0RbRuFrlqz/PcTQjfb2DOfQ=="
+      },
+      "coordimporter": {
+        "type": "Project",
+        "dependencies": {
+          "CSharpFunctionalExtensions": "[2.40.3, )",
+          "DalamudPackager": "[2.1.12, )"
+        }
+      }
+    }
+  }
+}

--- a/CoordImporter.sln
+++ b/CoordImporter.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29709.97
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoordImporter", "CoordImporter\CoordImporter.csproj", "{13C812E9-0D42-4B95-8646-40EEBF30636F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoordImporter.Tests", "CoordImporter.Tests\CoordImporter.Tests.csproj", "{3E141DBB-5E5F-4ECD-84A7-8BC745548BB8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -19,6 +21,10 @@ Global
 		{4FEC9558-EB25-419F-B86E-51B8CFDA32B7}.Debug|x64.Build.0 = Debug|x64
 		{4FEC9558-EB25-419F-B86E-51B8CFDA32B7}.Release|x64.ActiveCfg = Release|x64
 		{4FEC9558-EB25-419F-B86E-51B8CFDA32B7}.Release|x64.Build.0 = Release|x64
+		{3E141DBB-5E5F-4ECD-84A7-8BC745548BB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3E141DBB-5E5F-4ECD-84A7-8BC745548BB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{3E141DBB-5E5F-4ECD-84A7-8BC745548BB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{3E141DBB-5E5F-4ECD-84A7-8BC745548BB8}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CoordImporter/Managers/DataManagerManager.cs
+++ b/CoordImporter/Managers/DataManagerManager.cs
@@ -32,12 +32,12 @@ public class DataManagerManager : IDataManagerManager
     
     public Maybe<uint> GetMobIdByName(string mobName)
     {
-        if (MobIdsByName.TryGetValue(mobName, out var mobId)) return mobId;
+        if (MobIdsByName.TryGetValue(mobName.ToLowerInvariant(), out var mobId)) return mobId;
         return Maybe.None;
     }
     public Maybe<MapData> GetMapDataByName(string mapName)
     {
-        if (MapDataByName.TryGetValue(mapName, out var map)) return map;
+        if (MapDataByName.TryGetValue(mapName.ToLowerInvariant(), out var map)) return map;
         return Maybe.None;
     }
     
@@ -85,7 +85,7 @@ public class DataManagerManager : IDataManagerManager
                     Plugin.Logger.Verbose("Failed to load PlaceName");
                     continue;
                 }
-                var placeName = placeNameValue.Name.ToString();
+                var placeName = placeNameValue.Name.ToString().ToLowerInvariant();
 
                 var mapData = new MapData(territory.RowId, territory.Map.Row);
 

--- a/CoordImporter/Managers/DataManagerManager.cs
+++ b/CoordImporter/Managers/DataManagerManager.cs
@@ -2,6 +2,7 @@
 using CSharpFunctionalExtensions;
 using Dalamud;
 using Dalamud.Plugin.Services;
+using Lumina.Excel;
 using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
@@ -10,37 +11,49 @@ using System.Linq;
 
 namespace CoordImporter.Managers;
 
-public static class DataManagerExtensions
+public class DataManagerManager : IDataManagerManager
 {
-    #region mark name data
-    private static IReadOnlyDictionary<string, uint>? MobIdsByName;
-    public static IReadOnlyDictionary<string, uint> GetMobIdsByName(this IDataManager dataManager) =>
-        MobIdsByName ??= LoadMobIds();
-
-    public static uint? GetMobIdByName(this IDataManager dataManager, string name)
+    private readonly IDataManager dataManager;
+    
+    private IReadOnlyDictionary<string, uint> MobIdsByName { get; init; }
+    private IReadOnlyDictionary<string, MapData> MapDataByName { get; init; }
+    
+    public DataManagerManager(IDataManager dataManager)
     {
-        var valueGotten = dataManager.GetMobIdsByName().TryGetValue(
-            name.ToLowerInvariant(),
-            out var mobId
-        );
-        if (valueGotten) return mobId;
-        return null;
-    }
+        this.dataManager = dataManager;
 
-    private static IReadOnlyDictionary<string, uint> LoadMobIds() =>
+        MobIdsByName = LoadMobIds();
+        MapDataByName = LoadMapData();
+    }
+    public ExcelSheet<T>? GetExcelSheet<T>() where T : ExcelRow => dataManager.GetExcelSheet<T>();
+    
+    public ExcelSheet<T>? GetExcelSheet<T>(ClientLanguage clientLanguage) where T : ExcelRow =>
+        dataManager.GetExcelSheet<T>(clientLanguage);
+    
+    public Maybe<uint> GetMobIdByName(string mobName)
+    {
+        if (MobIdsByName.TryGetValue(mobName, out var mobId)) return mobId;
+        return Maybe.None;
+    }
+    public Maybe<MapData> GetMapDataByName(string mapName)
+    {
+        if (MapDataByName.TryGetValue(mapName, out var map)) return map;
+        return Maybe.None;
+    }
+    
+    private IReadOnlyDictionary<string, uint> LoadMobIds() =>
         (Enum.GetValuesAsUnderlyingType<ClientLanguage>() as ClientLanguage[])!
         .Select(clientLanguage =>
         {
             Plugin.Logger.Verbose($"Loading mark names for language: {clientLanguage}");
 
-            return Plugin
-                .DataManager.GetExcelSheet<BNpcName>(clientLanguage)
+            return dataManager.GetExcelSheet<BNpcName>(clientLanguage)
                 .AsMaybe(() => Plugin.Logger.Verbose($"Could not find BNpcName sheet for language: {clientLanguage}"))
                 .Select(nameSheet => nameSheet as IEnumerable<BNpcName>)
                 .GetValueOrDefault(new List<BNpcName>())
                 .Select(name => ((uint RowId, string Name))(name.RowId, name.Singular.ToString().ToLowerInvariant()))
                 .ForEach(name =>
-                        Plugin.Logger.Verbose("Found mobId [{0}] for name: {1}", name.RowId, name.Name)
+                    Plugin.Logger.Verbose("Found mobId [{0}] for name: {1}", name.RowId, name.Name)
                 );
         })
         .Flatten()
@@ -49,14 +62,8 @@ public static class DataManagerExtensions
             name => name.Name,
             name => name.RowId
         );
-    #endregion
-
-    #region map data
-    private static IReadOnlyDictionary<string, MapData>? MapDataByName;
-    public static IReadOnlyDictionary<string, MapData> GetMapDataByName(this IDataManager dataManager) =>
-        MapDataByName ??= LoadMapData();
-
-    private static IReadOnlyDictionary<string, MapData> LoadMapData()
+    
+    private IReadOnlyDictionary<string, MapData> LoadMapData()
     {
         // This should support names of maps in all available languages. We create a dictionary where the key is the
         // name of the map (in whatever language) and the value is the map data we care about.
@@ -66,8 +73,8 @@ public static class DataManagerExtensions
         foreach (var clientLanguage in clientLanguages)
         {
             Plugin.Logger.Verbose($"Loading map data for language: {clientLanguage}");
-            var territorySheet = Plugin.DataManager.GetExcelSheet<TerritoryType>(clientLanguage);
-            var placeSheet = Plugin.DataManager.GetExcelSheet<PlaceName>(clientLanguage);
+            var territorySheet = dataManager.GetExcelSheet<TerritoryType>(clientLanguage);
+            var placeSheet = dataManager.GetExcelSheet<PlaceName>(clientLanguage);
             if (territorySheet == null || placeSheet == null) continue;
 
             foreach (var territory in territorySheet)
@@ -93,5 +100,4 @@ public static class DataManagerExtensions
 
         return mapDict.ToImmutableDictionary();
     }
-    #endregion
 }

--- a/CoordImporter/Managers/HuntHelperManager.cs
+++ b/CoordImporter/Managers/HuntHelperManager.cs
@@ -121,11 +121,12 @@ public class HuntHelperManager : IDisposable {
     private static Maybe<TrainMark> ToTrainMark(MarkData markData)
     {
         return Plugin
-            .DataManager.GetMobIdByName(markData.MarkName)
-            .AsMaybe(() =>
+            .DataManagerManager.GetMobIdByName(markData.MarkName)
+            .Or(() =>
             {
                 Plugin.Logger.Warning("Could not find MobId for hunt mark: {0}", markData.MarkName);
                 Plugin.Chat.PrintError($"Skipping mark [{markData.MarkName}] -- could not find its MobId ;-;");
+                return Maybe.None;
             })
             .Select(mobId => new TrainMark(
                 markData.MarkName,

--- a/CoordImporter/Managers/IDataManagerManager.cs
+++ b/CoordImporter/Managers/IDataManagerManager.cs
@@ -1,0 +1,18 @@
+﻿using CoordImporter.Parser;
+using CSharpFunctionalExtensions;
+using Dalamud;
+using Lumina.Excel;
+using Lumina.Excel.GeneratedSheets;
+
+namespace CoordImporter.Managers;
+
+public interface IDataManagerManager
+{
+    #region lumina methods
+    ExcelSheet<T>? GetExcelSheet<T>() where T : ExcelRow;
+    ExcelSheet<T>? GetExcelSheet<T>(ClientLanguage clientLanguage) where T : ExcelRow;
+    #endregion
+    
+    Maybe<uint> GetMobIdByName(string mobName);
+    Maybe<MapData> GetMapDataByName(string mapName);
+}

--- a/CoordImporter/Parser/Parsers.cs
+++ b/CoordImporter/Parser/Parsers.cs
@@ -67,7 +67,7 @@ public partial class SirenParser : ITrackerParser
     private static readonly char I1Char = SeIconChar.Instance1.ToIconChar();
     
     // For the format "(Maybe: Storsie) {LinkChar}Labyrinthos{I1Char} ( 17  , 9.6 ) "
-    [GeneratedRegex($@"\(Maybe: (?<mark_name>[\w+ '-]+)\) \ue0bb(?<map_name>[\w+ '-]+)(?<instance>[\ue0b1-\ue0b9]?)\s+\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)", RegexOptions.Compiled)]
+    [GeneratedRegex($@"\((Maybe: )?(?<mark_name>[\w '-]+)\) \ue0bb(?<map_name>[\w '-]+)(?<instance>[\ue0b1-\ue0b9]?)\s+\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)")]
     private static partial Regex SirenRegex();
 
     public bool CanParseLine(string inputLine) => SirenRegex().IsMatch(inputLine);
@@ -83,7 +83,7 @@ public partial class SirenParser : ITrackerParser
 public partial class FaloopParser : ITrackerParser
 {
     // For the format "Raiden [S]: Gamma - Yanxia ( 23.6, 11.4 )"
-    [GeneratedRegex(@"(?<world_name>[a-zA-Z0-9'-]+)\s+\[S\]: (?<mark_name>[\w+ '-]+) - (?<map_name>[\w+ '-]+)\s+\(?(?<instance>[1-9]?)\)?\s*\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)", RegexOptions.Compiled)]
+    [GeneratedRegex(@"(?<world_name>[a-zA-Z0-9'-]+)\s+\[S\]: (?<mark_name>[\w '-]+) - (?<map_name>[\w '-]+)\s+\(?(?<instance>[1-9]?)\)?\s*\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)")]
     private static partial Regex FaloopRegex();
 
     public bool CanParseLine(string inputLine) => FaloopRegex().IsMatch(inputLine);
@@ -99,7 +99,7 @@ public partial class FaloopParser : ITrackerParser
 public partial class BearParser : ITrackerParser
 {
     // For the format "Labyrinthos ( 16.5 , 16.8 ) Storsie"
-    [GeneratedRegex(@"(?<map_name>[\D'\s+-]+)\s*(?<instance>[1-9]?)\s*\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)\s*(?<mark_name>\w[\w +-]+)", RegexOptions.Compiled)]
+    [GeneratedRegex(@"(?<map_name>[\D'\s-]+)\s*(?<instance>[1-9]?)\s*\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)\s*(?<mark_name>\w[\w -]+)")]
     private static partial Regex BearRegex();
 
     public bool CanParseLine(string inputLine) => BearRegex().IsMatch(inputLine);

--- a/CoordImporter/Parser/Parsers.cs
+++ b/CoordImporter/Parser/Parsers.cs
@@ -62,60 +62,51 @@ public interface ITrackerParser
     Result<MarkData, string> Parse(string inputLine);
 }
 
-public class SirenParser : ITrackerParser
+public partial class SirenParser : ITrackerParser
 {
-    private static readonly char LinkChar = SeIconChar.LinkMarker.ToIconChar();
     private static readonly char I1Char = SeIconChar.Instance1.ToIconChar();
-    private static readonly char I9Char = SeIconChar.Instance9.ToIconChar();
     
     // For the format "(Maybe: Storsie) {LinkChar}Labyrinthos{I1Char} ( 17  , 9.6 ) "
-    private static readonly Regex SirenRegex = new Regex(
-        $@"\(Maybe: (?<mark_name>[\w+ '-]+)\) {LinkChar}(?<map_name>[\w+ '-]+)(?<instance>[{I1Char}-{I9Char}]?)\s+\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)",
-        RegexOptions.Compiled);
+    [GeneratedRegex($@"\(Maybe: (?<mark_name>[\w+ '-]+)\) \ue0bb(?<map_name>[\w+ '-]+)(?<instance>[\ue0b1-\ue0b9]?)\s+\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)", RegexOptions.Compiled)]
+    private static partial Regex SirenRegex();
 
-    public bool CanParseLine(string inputLine) => SirenRegex.IsMatch(inputLine);
+    public bool CanParseLine(string inputLine) => SirenRegex().IsMatch(inputLine);
 
     public Result<MarkData, string> Parse(string inputLine)
     {
-        var groups = SirenRegex.Matches(inputLine).First().Groups;
+        var groups = SirenRegex().Matches(inputLine).First().Groups;
         ITrackerParser.LogParse("Siren", inputLine, groups);
         return groups.CreateMark(instance => (uint)(instance.First() - I1Char) + 1);
     }
 }
 
-public class FaloopParser : ITrackerParser
+public partial class FaloopParser : ITrackerParser
 {
     // For the format "Raiden [S]: Gamma - Yanxia ( 23.6, 11.4 )"
-    private static readonly Regex FaloopRegex = new Regex(
-        @"(?<world_name>[a-zA-Z0-9'-]+)\s+\[S\]: (?<mark_name>[\w+ '-]+) - (?<map_name>[\w+ '-]+)\s+\(?(?<instance>[1-9]?)\)?\s*\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)",
-        RegexOptions.Compiled);
+    [GeneratedRegex(@"(?<world_name>[a-zA-Z0-9'-]+)\s+\[S\]: (?<mark_name>[\w+ '-]+) - (?<map_name>[\w+ '-]+)\s+\(?(?<instance>[1-9]?)\)?\s*\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)", RegexOptions.Compiled)]
+    private static partial Regex FaloopRegex();
 
-    public bool CanParseLine(string inputLine) => FaloopRegex.IsMatch(inputLine);
+    public bool CanParseLine(string inputLine) => FaloopRegex().IsMatch(inputLine);
 
     public Result<MarkData, string> Parse(string inputLine)
     {
-        var groups = FaloopRegex.Matches(inputLine).First().Groups;
+        var groups = FaloopRegex().Matches(inputLine).First().Groups;
         ITrackerParser.LogParse("Faloop", inputLine, groups);
         return groups.CreateMark(instance => (uint)(instance.First() - '0'));
     }
 }
 
-public class BearParser : ITrackerParser
+public partial class BearParser : ITrackerParser
 {
     // For the format "Labyrinthos ( 16.5 , 16.8 ) Storsie"
-    private static readonly Regex BearRegex = new Regex(
-        @"(?<map_name>[\D'\s+-]+)\s*(?<instance>[1-9]?)\s*\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)\s*(?<mark_name>\w[\w +-]+)",
-        RegexOptions.Compiled);
+    [GeneratedRegex(@"(?<map_name>[\D'\s+-]+)\s*(?<instance>[1-9]?)\s*\(\s*(?<x_coord>[0-9\.]+)\s*,\s*(?<y_coord>[0-9\.]+)\s*\)\s*(?<mark_name>\w[\w +-]+)", RegexOptions.Compiled)]
+    private static partial Regex BearRegex();
 
-    public bool CanParseLine(string inputLine)
-    {
-        var matches = BearRegex.Matches(inputLine);
-        return BearRegex.IsMatch(inputLine);
-    }
+    public bool CanParseLine(string inputLine) => BearRegex().IsMatch(inputLine);
 
     public Result<MarkData, string> Parse(string inputLine)
     {
-        var groups = BearRegex.Matches(inputLine).First().Groups;
+        var groups = BearRegex().Matches(inputLine).First().Groups;
         ITrackerParser.LogParse("Bear", inputLine, groups);
         return groups.CreateMark(instance => (uint)(instance.First() - '0'));
     }

--- a/CoordImporter/Plugin.cs
+++ b/CoordImporter/Plugin.cs
@@ -1,22 +1,11 @@
 ﻿using CoordImporter.Managers;
-using CoordImporter.Parser;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
+using CoordImporter.Windows;
 using Dalamud.Game.Command;
+using Dalamud.Interface.Windowing;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
-using System.Text.RegularExpressions;
-using Dalamud.Game.Text;
-using Dalamud.Game.Text.SeStringHandling;
-using Dalamud.Game.Text.SeStringHandling.Payloads;
-using Dalamud.Interface.Windowing;
-using Dalamud.Utility;
 using Lumina.Excel.GeneratedSheets;
-using CoordImporter.Windows;
-using Dalamud;
 
 namespace CoordImporter
 {
@@ -25,12 +14,13 @@ namespace CoordImporter
         public string Name => "Coordinate Importer";
         private const string CommandName = "/ci";
 
-        public static DalamudPluginInterface PluginInterface { get; private set; }
+        public static DalamudPluginInterface PluginInterface { get; set; } = null!;
+        public static IChatGui Chat { get; set; } = null!;
+        public static IPluginLog Logger { get; set; } = null!;
+        public static IDataManagerManager DataManagerManager { get; set; } = null!;
+
         private ICommandManager CommandManager { get; init; }
         private WindowSystem WindowSystem { get; } = new WindowSystem("CoordinateImporter");
-        public static IChatGui Chat { get; private set; } = null!;
-        public static IDataManager DataManager { get; private set; } = null!;
-        public static IPluginLog Logger { get; private set; } = null!;
         
         private HuntHelperManager HuntHelperManager { get; init; }
 
@@ -46,14 +36,14 @@ namespace CoordImporter
             PluginInterface = pluginInterface;
             this.CommandManager = commandManager;
             Chat = chat;
-            DataManager = dataManager;
             Logger = logger;
+            DataManagerManager = new DataManagerManager(dataManager);
 
             HuntHelperManager = new HuntHelperManager();
 
             // Invalidate the Placename cache because the sheet in here may not correspond to the correct ClientLanguage.
             // This is because Lumina caches the sheets but it doesn't seem to properly manage the language as part of the caching
-            DataManager.Excel.RemoveSheetFromCache<PlaceName>();
+            dataManager.Excel.RemoveSheetFromCache<PlaceName>();
             MainWindow = new MainWindow(HuntHelperManager);
 
             WindowSystem.AddWindow(MainWindow);

--- a/CoordImporter/Plugin.cs
+++ b/CoordImporter/Plugin.cs
@@ -41,9 +41,6 @@ namespace CoordImporter
 
             HuntHelperManager = new HuntHelperManager();
 
-            // Invalidate the Placename cache because the sheet in here may not correspond to the correct ClientLanguage.
-            // This is because Lumina caches the sheets but it doesn't seem to properly manage the language as part of the caching
-            dataManager.Excel.RemoveSheetFromCache<PlaceName>();
             MainWindow = new MainWindow(HuntHelperManager);
 
             WindowSystem.AddWindow(MainWindow);

--- a/CoordImporter/Windows/MainWindow.cs
+++ b/CoordImporter/Windows/MainWindow.cs
@@ -15,7 +15,7 @@ using System.Numerics;
 
 namespace CoordImporter.Windows;
 
-public class MainWindow : Window, IDisposable
+public sealed class MainWindow : Window, IDisposable
 {
     private string textBuffer = string.Empty;
     private HuntHelperManager huntHelperManager;
@@ -24,7 +24,7 @@ public class MainWindow : Window, IDisposable
     {
         this.SizeConstraints = new WindowSizeConstraints
         {
-            MinimumSize = new Vector2(100, 65),
+            MinimumSize = new Vector2(100, 85),
             MaximumSize = new Vector2(float.MaxValue, float.MaxValue)
         };
 


### PR DESCRIPTION
added unit tests for the parsers. in order to pull that off, it was necessary to wrap lumina in an interface, for mocking. i'm not happy about that, but tried a lot of things before just accepting that reality >:C

also of note, the tests really look like they could be parameterized, but surprise surprise, c# parameterization of tests has a bunch of catches and special conditions and it was too annoying so i gave up on it and just wrote the tests the way they are now.