### PR TITLE
fix non-lumina names present in some tracker output

### DIFF
--- a/CoordImporter.Tests/Managers/CiDataManagerTests.cs
+++ b/CoordImporter.Tests/Managers/CiDataManagerTests.cs
@@ -1,0 +1,76 @@
+﻿using CoordImporter.Managers;
+
+namespace CoordImporter.Tests.Managers;
+
+[TestFixture]
+public class CiDataManagerTests
+{
+    // some names to test with. yes these are copied from the json, but don't think we need to verify ALL names in the json
+    private static readonly IReadOnlyDictionary<string, string> TestCorrectedMarkNames = new Dictionary<string, string>()
+    {
+        { "Dalvags Final Flame", "Dalvag's Final Flame" },
+        { "Lil Murderer", "Li'l Murderer" },
+        { "Zanigoh", "Zanig'oh" },
+    };
+
+    private static readonly IReadOnlyList<string> TestUnchangedMarkNames = new[]
+    {
+        "Yilan",
+        "Stolas",
+        "anything, honestly",
+    };
+    
+    private readonly CiDataManager ciDataManager = new CiDataManager(@"Data\CustomNames.json");
+
+    [Test]
+    public void CorrectedMarkNames()
+    {
+        Assert.Multiple(() =>
+        {
+            TestCorrectedMarkNames.ForEach(correctedName =>
+            {
+                // DATA
+                var expected = correctedName.Value;
+                
+                // WHEN
+                var actual = ciDataManager.CorrectMarkName(correctedName.Key);
+                
+                // THEN
+                Assert.That(actual, Is.EqualTo(expected));
+            });
+        });
+    }
+
+    [Test]
+    public void UnchangedMarkNames()
+    {
+        Assert.Multiple(() =>
+        {
+            TestUnchangedMarkNames.ForEach(unchangedName =>
+            {
+                // DATA
+                var expected = unchangedName;
+                
+                // WHEN
+                var actual = ciDataManager.CorrectMarkName(unchangedName);
+                
+                // THEN
+                Assert.That(actual, Is.EqualTo(expected));
+            });
+        });
+    }
+
+    [Test]
+    public void CorrectingNamesIsCaseInsensitive()
+    {
+        // DATA
+        var input = "ZANIGOH";
+        var expected = "Zanig'oh";
+
+        // WHEN
+        var actual = ciDataManager.CorrectMarkName(input);
+
+        // THEN
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+}

--- a/CoordImporter/CoordImporter.csproj
+++ b/CoordImporter/CoordImporter.csproj
@@ -28,4 +28,10 @@
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1"/>
     </ItemGroup>
+
+    <ItemGroup>
+      <EmbeddedResource Include="Data\CustomNames.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </EmbeddedResource>
+    </ItemGroup>
 </Project>

--- a/CoordImporter/Data/CustomNames.json
+++ b/CoordImporter/Data/CustomNames.json
@@ -1,0 +1,9 @@
+﻿{
+    "siren": {
+        "Dalvags Final Flame": "Dalvag's Final Flame",
+        "Lil Murderer": "Li'l Murderer",
+        "Zanigoh": "Zanig'oh"
+    },
+    "faloop": { },
+    "bear": { }
+}

--- a/CoordImporter/Importer.cs
+++ b/CoordImporter/Importer.cs
@@ -1,9 +1,10 @@
-﻿using CoordImporter.Parser;
-using CSharpFunctionalExtensions;
+﻿using CSharpFunctionalExtensions;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using CoordImporter.Models;
+using CoordImporter.Parsers;
 
 namespace CoordImporter;
 

--- a/CoordImporter/Managers/CiDataManager.cs
+++ b/CoordImporter/Managers/CiDataManager.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CoordImporter.Managers;
+
+using CorrectionDict = IReadOnlyDictionary<string, string>;
+
+public class CiDataManager : ICiDataManager
+{
+    private readonly CorrectionDict corrections;
+    
+    public CiDataManager(string customNamesFilename)
+    {
+        corrections = LoadCorrections(customNamesFilename);
+    }
+    
+    public string CorrectMarkName(string markName)
+    {
+        return corrections.TryGetValue(markName.ToLowerInvariant(), out var correction) ? correction : markName;
+    }
+
+    public string CorrectMapName(string mapName)
+    {
+        return corrections.TryGetValue(mapName.ToLowerInvariant(), out var correction) ? correction : mapName;
+    }
+
+    private static CorrectionDict LoadCorrections(string customNamesFilename)
+    {
+        return JsonConvert.DeserializeObject<IDictionary<string, JObject>>(File.ReadAllText(customNamesFilename))!
+            .SelectMany(trackerCustomizations =>
+            {
+                var tracker = trackerCustomizations.Key!;
+                var customizations = trackerCustomizations.Value! as IDictionary<string, JToken?>;
+                return customizations
+                    .Select(correction =>
+                    {
+                        var nameFromTracker = correction.Key!.ToLowerInvariant();
+                        var correctName = correction.Value!.Value<string>()!;
+                        return (nameFromTracker, correctName);
+                    });
+            })
+            .ToImmutableDictionary(
+                correction => correction.nameFromTracker,
+                correction => correction.correctName
+            );
+    }
+}

--- a/CoordImporter/Managers/DataManagerManager.cs
+++ b/CoordImporter/Managers/DataManagerManager.cs
@@ -1,5 +1,4 @@
-﻿using CoordImporter.Parser;
-using CSharpFunctionalExtensions;
+﻿using CSharpFunctionalExtensions;
 using Dalamud;
 using Dalamud.Plugin.Services;
 using Lumina.Excel;
@@ -8,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using CoordImporter.Models;
 
 namespace CoordImporter.Managers;
 

--- a/CoordImporter/Managers/HuntHelperManager.cs
+++ b/CoordImporter/Managers/HuntHelperManager.cs
@@ -1,11 +1,11 @@
-﻿using CoordImporter.Parser;
-using CSharpFunctionalExtensions;
+﻿using CSharpFunctionalExtensions;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Ipc.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using CoordImporter.Models;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 

--- a/CoordImporter/Managers/ICiDataManager.cs
+++ b/CoordImporter/Managers/ICiDataManager.cs
@@ -1,0 +1,8 @@
+﻿namespace CoordImporter.Managers;
+
+public interface ICiDataManager
+{
+    string CorrectMarkName(string markName);
+    
+    string CorrectMapName(string mapName);
+}

--- a/CoordImporter/Managers/IDataManagerManager.cs
+++ b/CoordImporter/Managers/IDataManagerManager.cs
@@ -1,8 +1,7 @@
-﻿using CoordImporter.Parser;
+﻿using CoordImporter.Models;
 using CSharpFunctionalExtensions;
 using Dalamud;
 using Lumina.Excel;
-using Lumina.Excel.GeneratedSheets;
 
 namespace CoordImporter.Managers;
 

--- a/CoordImporter/Models/MapData.cs
+++ b/CoordImporter/Models/MapData.cs
@@ -1,4 +1,4 @@
-﻿namespace CoordImporter.Parser;
+﻿namespace CoordImporter.Models;
 
 public record struct MapData(
     uint TerritoryId,

--- a/CoordImporter/Models/MarkData.cs
+++ b/CoordImporter/Models/MarkData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Numerics;
 
-namespace CoordImporter.Parser;
+namespace CoordImporter.Models;
 
 public record struct MarkData(
     string MarkName,

--- a/CoordImporter/Parsers/BaseParser.cs
+++ b/CoordImporter/Parsers/BaseParser.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using System.Numerics;
 using System.Text.RegularExpressions;
 using CoordImporter.Managers;
+using CoordImporter.Models;
 using CSharpFunctionalExtensions;
-using Dalamud.Game.Text;
 using Dalamud.Plugin.Services;
 
-namespace CoordImporter.Parser;
+namespace CoordImporter.Parsers;
 
 public interface ITrackerParser
 {
@@ -17,15 +17,17 @@ public interface ITrackerParser
     public Result<MarkData, string> Parse(string inputLine);
 }
 
-public abstract class Parser : ITrackerParser
+public abstract class BaseParser : ITrackerParser
 {
     private IPluginLog Logger { get; init; }
     private IDataManagerManager DataManagerManager { get; init; }
+    private ICiDataManager CiDataManager { get; init; }
 
-    protected Parser(IPluginLog logger, IDataManagerManager dataManagerManager)
+    protected BaseParser(IPluginLog logger, IDataManagerManager dataManagerManager, ICiDataManager ciDataManager)
     {
         Logger = logger;
         DataManagerManager = dataManagerManager;
+        CiDataManager = ciDataManager;
     }
 
     protected Result<MarkData, string> CreateMark(GroupCollection groups, Func<string, uint> instanceParser)
@@ -39,7 +41,7 @@ public abstract class Parser : ITrackerParser
                )
                .Map(map =>
                {
-                   var markName = groups["mark_name"].Value;
+                   var markName = CiDataManager.CorrectMarkName(groups["mark_name"].Value);
                    var x = float.Parse(groups["x_coord"].Value, CultureInfo.InvariantCulture);
                    var y = float.Parse(groups["y_coord"].Value, CultureInfo.InvariantCulture);
                    var instance = groups["instance"]

--- a/CoordImporter/Parsers/BearParser.cs
+++ b/CoordImporter/Parsers/BearParser.cs
@@ -1,12 +1,13 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
 using CoordImporter.Managers;
+using CoordImporter.Models;
 using CSharpFunctionalExtensions;
 using Dalamud.Plugin.Services;
 
-namespace CoordImporter.Parser;
+namespace CoordImporter.Parsers;
 
-public class BearParser : Parser
+public class BearParser : BaseParser
 {
     // For the format "Labyrinthos ( 16.5 , 16.8 ) Storsie"
     protected readonly Regex Regex = new Regex(
@@ -22,5 +23,6 @@ public class BearParser : Parser
 
     public override bool CanParseLine(string inputLine) => Regex.IsMatch(inputLine);
 
-    public BearParser(IPluginLog logger, IDataManagerManager dataManagerManager) : base(logger, dataManagerManager) { }
+    public BearParser(IPluginLog logger, IDataManagerManager dataManagerManager, ICiDataManager ciDataManager)
+        : base(logger, dataManagerManager, ciDataManager) { }
 }

--- a/CoordImporter/Parsers/FaloopParser.cs
+++ b/CoordImporter/Parsers/FaloopParser.cs
@@ -1,12 +1,13 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
 using CoordImporter.Managers;
+using CoordImporter.Models;
 using CSharpFunctionalExtensions;
 using Dalamud.Plugin.Services;
 
-namespace CoordImporter.Parser;
+namespace CoordImporter.Parsers;
 
-public class FaloopParser : Parser
+public class FaloopParser : BaseParser
 {
     // For the format "Raiden [S]: Gamma - Yanxia ( 23.6, 11.4 )"
     protected readonly Regex Regex = new Regex(
@@ -23,5 +24,6 @@ public class FaloopParser : Parser
 
     public override bool CanParseLine(string inputLine) => Regex.IsMatch(inputLine);
 
-    public FaloopParser(IPluginLog logger, IDataManagerManager dataManagerManager) : base(logger, dataManagerManager) { }
+    public FaloopParser(IPluginLog logger, IDataManagerManager dataManagerManager, ICiDataManager ciDataManager)
+        : base(logger, dataManagerManager, ciDataManager) { }
 }

--- a/CoordImporter/Parsers/SirenParser.cs
+++ b/CoordImporter/Parsers/SirenParser.cs
@@ -1,13 +1,14 @@
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
 using CoordImporter.Managers;
+using CoordImporter.Models;
 using CSharpFunctionalExtensions;
 using Dalamud.Game.Text;
 using Dalamud.Plugin.Services;
 
-namespace CoordImporter.Parser;
+namespace CoordImporter.Parsers;
 
-public class SirenParser : Parser
+public class SirenParser : BaseParser
 {
     private static readonly char LinkChar = SeIconChar.LinkMarker.ToIconChar();
     private static readonly char I1Char = SeIconChar.Instance1.ToIconChar();
@@ -28,5 +29,6 @@ public class SirenParser : Parser
 
     public override bool CanParseLine(string inputLine) => Regex.IsMatch(inputLine);
 
-    public SirenParser(IPluginLog logger, IDataManagerManager dataManagerManager) : base(logger, dataManagerManager) { }
+    public SirenParser(IPluginLog logger, IDataManagerManager dataManagerManager, ICiDataManager ciDataManager)
+        : base(logger, dataManagerManager, ciDataManager) { }
 }

--- a/CoordImporter/Plugin.cs
+++ b/CoordImporter/Plugin.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
-using CoordImporter.Managers;
-using CoordImporter.Parser;
+﻿using CoordImporter.Managers;
+using CoordImporter.Parsers;
 using CoordImporter.Windows;
 using Dalamud.Game.Command;
 using Dalamud.Interface.Windowing;
@@ -35,6 +34,7 @@ namespace CoordImporter
             builder.Services.AddSingleton(chat);
             builder.Services.AddSingleton(dataManager);
             builder.Services.AddSingleton<IDataManagerManager, DataManagerManager>();
+            builder.Services.AddSingleton<ICiDataManager>(new CiDataManager(pluginInterface.DataFilePath("CustomNames.json")));
             builder.Services.AddSingleton<ITrackerParser, BearParser>();
             builder.Services.AddSingleton<ITrackerParser, FaloopParser>();
             builder.Services.AddSingleton<ITrackerParser, SirenParser>();

--- a/CoordImporter/Utils.cs
+++ b/CoordImporter/Utils.cs
@@ -1,13 +1,17 @@
-﻿using CSharpFunctionalExtensions;
-using Dalamud.Game.Text;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using CSharpFunctionalExtensions;
+using Dalamud.Game.Text;
+using Dalamud.Plugin;
 
 namespace CoordImporter;
 
 public static class Utils
 {
+    #region extentions
+
     public static IEnumerable<T> ForEach<T>(this IEnumerable<T> source, Action<T> action)
     {
         var values = source.ToList();
@@ -32,4 +36,12 @@ public static class Utils
         instance is >= 1 and <= 9
             ? (SeIconChar.Instance1 + (int)instance! - 1).ToIconString()
             : string.Empty;
+
+    public static string DataFilePath(this DalamudPluginInterface pluginInterface, string dataFilename) => Path.Combine(
+        pluginInterface.AssemblyLocation.Directory?.FullName!,
+        "Data",
+        dataFilename
+    );
+
+    #endregion
 }

--- a/CoordImporter/Windows/MainWindow.cs
+++ b/CoordImporter/Windows/MainWindow.cs
@@ -1,5 +1,4 @@
 using CoordImporter.Managers;
-using CoordImporter.Parser;
 using CSharpFunctionalExtensions;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
@@ -12,6 +11,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
+using CoordImporter.Models;
 using Dalamud.Plugin.Services;
 
 namespace CoordImporter.Windows;


### PR DESCRIPTION
fixes the fact that trackers don't necessarily give the same names as found in lumina, which will make parsing fail. we currently only know about siren doing this with apostrophes, but it was pretty easy to build the mechanism to be pretty generic.

i made it theoretically handle both map and mark names, even though we only know of mark names that are afflicted by this right now. it was pretty easy to just do for both. but behind the scenes they all share one correction dictionary because it didn't seem worth it to separate them when map and marks don't have any similar names. the config file is also separated by tracker, but doesn't care about that in the actual manager, it's just for better management of the data.

one last note: a lot of files were touched, but only because i noticed, when updating the parsers, that they and the models had the wrong namespaces, so i fixed those. can separate into their own pr, though, if it's a nuisance >_<.