### PR TITLE
Fix monsters not being loaded correctly for languages other than the client language

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       
       - name: Download Dalamud
         run: |

--- a/CoordImporter/CoordImporter.csproj
+++ b/CoordImporter/CoordImporter.csproj
@@ -5,7 +5,7 @@
     <PropertyGroup>
         <Authors>zw3lf;dit-zy</Authors>
         <Company></Company>
-        <Version>1.2.0.1</Version>
+        <Version>1.2.0.2</Version>
         <Description>Import map coordinates to echo chat.</Description>
         <Copyright>MIT</Copyright>
         <PackageProjectUrl>https://github.com/zw3lf/ffxiv-coord-importer</PackageProjectUrl>

--- a/CoordImporter/Managers/DataManagerManager.cs
+++ b/CoordImporter/Managers/DataManagerManager.cs
@@ -53,11 +53,11 @@ public class DataManagerManager : IDataManagerManager
             Logger.Verbose($"Loading mark names for language: {clientLanguage}");
 
             var nmNameIds = DataManager
-                .GetExcelSheet<NotoriousMonster>()
+                .GetExcelSheet<NotoriousMonster>(clientLanguage)
                 .AsMaybe(() => Logger.Verbose($"Could not find NotoriousMonster sheet for language: {clientLanguage}"))
                 .Select(nmSheet => nmSheet as IEnumerable<NotoriousMonster>)
                 .GetValueOrDefault(new List<NotoriousMonster>())
-                .Select(notoriousMonster => notoriousMonster.BNpcName.Value)
+                .Select(notoriousMonster => notoriousMonster.BNpcName.RowId)
                 .ToImmutableHashSet();
 
             return DataManager
@@ -65,14 +65,14 @@ public class DataManagerManager : IDataManagerManager
                 .AsMaybe(() => Logger.Verbose($"Could not find BNpcName sheet for language: {clientLanguage}"))
                 .Select(nameSheet => nameSheet as IEnumerable<BNpcName>)
                 .GetValueOrDefault(new List<BNpcName>())
-                .Where(name => nmNameIds.Contains(name))
+                .Where(name => nmNameIds.Contains(name.RowId))
                 // Bear and Siren have the apostrophe in different locations for Li'l Murderer, so just strip it out here
                 .Select(name => (
                         RowId: name.RowId,
                         Name: name.Singular.ToString().ToLowerInvariant().Replace("'", "")
                 ))
                 .ForEach(name =>
-                             Logger.Verbose("Found mobId [{0}] for name: {1}", name.RowId, name.Name)
+                             Logger.Verbose("Language: {0}: Found mobId [{1}] for name: {2}", clientLanguage, name.RowId, name.Name)
                 );
         })
         .Flatten()

--- a/CoordImporter/Managers/DataManagerManager.cs
+++ b/CoordImporter/Managers/DataManagerManager.cs
@@ -36,7 +36,7 @@ public class DataManagerManager : IDataManagerManager
     public Maybe<uint> GetMobIdByName(string mobName)
     {
         // Bear and Siren have the apostrophe in different locations for Li'l Murderer, so just strip it out here
-        if (MobIdsByName.TryGetValue(mobName.ToLowerInvariant().Replace("'", ""), out var mobId)) return mobId;
+        if (MobIdsByName.TryGetValue(mobName.ToLowerInvariant().Trim().Replace("'", ""), out var mobId)) return mobId;
         return Maybe.None;
     }
 


### PR DESCRIPTION
This probably broke with the DT lumina update but we didn't notice. Using `.Value` seems to not allow the `Contains` method work correctly so it was silently failing for languages there was not the game client's primary language (this is probably down to some silly caching or default value-reference somewhere in the bowels of lumina).

Using RowId seems to work since we are explicitly lifting a value from the sheet (or we're getting lucky that 'Monster X' in english has the same rowId as 'Monster X' in, say, German).